### PR TITLE
修正喷火驼拼音

### DIFF
--- a/src/pokemon/gen3.json
+++ b/src/pokemon/gen3.json
@@ -670,7 +670,7 @@
     {
         "phrase": "喷火驼",
         "input": [
-            "penghuotuo",
+            "penhuotuo",
             "pht",
             "camerupt",
             "bakuuda"


### PR DESCRIPTION
喷是前鼻音